### PR TITLE
Use hashed commit IDs

### DIFF
--- a/include/fvt/commit.h
+++ b/include/fvt/commit.h
@@ -22,7 +22,7 @@ struct commit : public version_control_feature
 
 // Make these private as they are not meant to be accessible or changed by other components of the code/users.
 private:
-    unsigned int commit_id;
+    std::string commit_id;
     std::string timestamp;
     std::vector<std::string> changed_files;
     std::string commit_message;
@@ -33,7 +33,7 @@ public:
      * @param id The unique ID of the commit.
      * @param files The list of files changed in this commit.
      */
-    commit(unsigned int id, const std::vector<std::string>& files, const std::string& message); 
+    commit(const std::vector<std::string>& files, const std::string& message);
 
     /**
      * @brief Copies a commit.
@@ -50,7 +50,7 @@ public:
      * @brief Gets the commit ID.
      * @return The unique commit ID.
      */
-    unsigned int get_commit_id() const;
+    std::string get_commit_id() const;
 
     /**
      * @brief Gets the list of changed files.
@@ -105,7 +105,8 @@ public:
 
 private:
     // Helper function to generate a timestamp
-    std::string create_timestamp(); 
+    std::string create_timestamp();
+    static std::string generate_hash(const std::string& data);
 };
 
 #endif

--- a/include/fvt/repository_branch.h
+++ b/include/fvt/repository_branch.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <iostream>
 #include "version_control_feature.h"
+#include "commit.h"
 
 /**
  * @brief Represents a branch in the repository.
@@ -13,7 +14,7 @@ class branch : public version_control_feature
 private:
     std::string branch_name;
     // The commit ID this branch is pointing to
-    unsigned int commit_id; 
+    std::string commit_id;
     // Branch needs to point to the commit ID it was created from but also have own unique ID.
     unsigned int branch_id; 
     commit* latest_commit;
@@ -26,8 +27,8 @@ public:
      * @param branch_id The unique ID of the branch.
      * @param latest_commit The latest commit object.
      */
-    branch(const std::string& name, unsigned int commit_id, unsigned int branch_id, commit* latest_commit)
-        : version_control_feature(name), // Call base class constructor 
+    branch(const std::string& name, const std::string& commit_id, unsigned int branch_id, commit* latest_commit)
+        : version_control_feature(name), // Call base class constructor
         branch_name(name), commit_id(commit_id),
         branch_id(branch_id), latest_commit(latest_commit) {}
 
@@ -54,7 +55,7 @@ public:
      * @brief Gets the commit ID of the latest commit on the branch.
      * @return The commit ID.
      */
-    unsigned int get_commit_id() const {
+    std::string get_commit_id() const {
         return commit_id;
     }
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -232,21 +232,16 @@ void handle_checkout(const std::string &argument) {
         return;
     }
 
-    // Determine if the argument is a branch name or a commit ID
-    if (std::isdigit(argument[0])) {
-        // Argument is a commit ID
-        unsigned int commit_id = std::stoi(argument);
-        for (const auto& c : repo->get_commit_history()) {
-            if (c.get_commit_id() == commit_id) {
-                repo->checkout_commit(std::to_string(commit_id));
-                return;
-            }
+    // Determine if the argument matches a commit ID
+    for (const auto& c : repo->get_commit_history()) {
+        if (c.get_commit_id() == argument) {
+            repo->checkout_commit(argument);
+            return;
         }
-        std::cerr << "Error: Commit ID '" << commit_id << "' not found.\n";
-    } else {
-        // Argument is a branch name
-        repo->checkout_branch(argument);
     }
+
+    // Otherwise treat the argument as a branch name
+    repo->checkout_branch(argument);
 }
 
 /**

--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -56,7 +56,7 @@ void repository::show_commit_log()
 
         // Write commit ID
         strncpy(buffer, "Commit ID: ", sizeof(buffer));
-        strncat(buffer, std::to_string(c.get_commit_id()).c_str(), sizeof(buffer) - strlen(buffer) - 1);
+        strncat(buffer, c.get_commit_id().c_str(), sizeof(buffer) - strlen(buffer) - 1);
         strncat(buffer, "\n", sizeof(buffer) - strlen(buffer) - 1);
 
         // Write timestamp
@@ -93,7 +93,6 @@ void repository::create_branch(const std::string &branch_name)
     branches.emplace_back(branch(branch_name, latest_commit->get_commit_id(), branch_id, latest_commit));
 
     std::cout << "Created new branch: " << branch_name << " pointing to commit " << latest_commit->get_commit_id() << std::endl;
-    unsigned int latest_commit_id = commit_history.back().get_commit_id();
 }
 
 void repository::get_branches()
@@ -127,7 +126,7 @@ void repository::checkout_commit(const std::string &commit_id)
 {
     for (const auto &c : commit_history)
     {
-        if (std::to_string(c.get_commit_id()) == commit_id)
+        if (c.get_commit_id() == commit_id)
         {
             std::cout << "Switched to commit: " << commit_id << std::endl;
             return;


### PR DESCRIPTION
## Summary
- replace numeric commit IDs with hashed strings
- implement hash generation using FNV-1a
- update branch and repository logic for string commit IDs
- adjust checkout command to detect hashed IDs

## Testing
- `make exe` *(fails: SDL dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843818b2e38832794144678826c31f5